### PR TITLE
Updated VARIANT parameter name (Fixes #6)

### DIFF
--- a/wyoming_tts_server.py
+++ b/wyoming_tts_server.py
@@ -397,7 +397,7 @@ async def main() -> None:
     os.environ["MODEL_VARIANT"] = args.variant
     variant = os.environ.get("MODEL_VARIANT", MODEL_VARIANT)
     _LOGGER.info("Loading Pocket-TTS model (variant: %s)...", variant)
-    tts_model = TTSModel.load_model(variant=variant)
+    tts_model = TTSModel.load_model(config=variant)
     _LOGGER.info("Model loaded successfully")
     _LOGGER.info("Sample rate: %d Hz", tts_model.sample_rate)
 


### PR DESCRIPTION
Due to a recent update in pocket-tts an error occurs that crashes docker run as reports in Issue #6 
Error is due to an update to parameters for pocket_tts/models/tts_model.py last month (https://github.com/kyutai-labs/pocket-tts/commit/28b8244428cad108e0fc5634b81207d09168412d)
Parameter changed from "variant" to "config" (line 400)
PR Closes #6 