### PR TITLE
Fix container crash on pocket-tts v2.0.0+ (breaking API changes)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM ghcr.io/astral-sh/uv:debian
-
 WORKDIR /app
-
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
-
-RUN git clone https://github.com/kyutai-labs/pocket-tts.git .
-
+RUN git clone --depth 1 https://github.com/kyutai-labs/pocket-tts.git . && rm -rf .git
 COPY wyoming_tts_server.py .
 
-ENV UV_TORCH_BACKEND=cpu
+# UV_TORCH_BACKEND has no effect on `uv add`/`uv lock`/`uv sync`/`uv run` —
+# it only applies to the `uv pip` / `uv tool` interfaces. For project
+# workflows, the CPU index has to be pinned in pyproject.toml instead.
+RUN printf '\n[[tool.uv.index]]\nname = "pytorch-cpu"\nurl = "https://download.pytorch.org/whl/cpu"\nexplicit = true\n\n[tool.uv.sources]\ntorch = { index = "pytorch-cpu" }\n' >> pyproject.toml
 
+RUN rm -f uv.lock
 RUN uv add "wyoming>=1.8,<2" zeroconf
-RUN uv add "torch" --index https://download.pytorch.org/whl/cpu --reinstall
-RUN uv sync
+RUN uv lock
+RUN uv sync --frozen
 
 ENV WYOMING_PORT=10201
 ENV WYOMING_HOST=0.0.0.0
@@ -22,4 +22,4 @@ ENV PYTHONUNBUFFERED=1
 
 EXPOSE 10201
 
-CMD ["uv", "run", "python", "wyoming_tts_server.py"]
+CMD ["uv", "run", "--no-sync", "python", "wyoming_tts_server.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY wyoming_tts_server.py .
 ENV UV_TORCH_BACKEND=cpu
 
 RUN uv add "wyoming>=1.8,<2" zeroconf
-RUN uv sync --frozen --no-dev || uv sync
+RUN uv add "torch" --index https://download.pytorch.org/whl/cpu --reinstall
+RUN uv sync
 
 ENV WYOMING_PORT=10201
 ENV WYOMING_HOST=0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,15 @@ RUN git clone https://github.com/kyutai-labs/pocket-tts.git .
 
 COPY wyoming_tts_server.py .
 
+ENV UV_TORCH_BACKEND=cpu
+
 RUN uv add "wyoming>=1.8,<2" zeroconf
+RUN uv sync --frozen --no-dev || uv sync
 
 ENV WYOMING_PORT=10201
 ENV WYOMING_HOST=0.0.0.0
 ENV DEFAULT_VOICE=alba
-ENV MODEL_VARIANT=b6369a24
+ENV MODEL_VARIANT=english
 ENV PYTHONUNBUFFERED=1
 
 EXPOSE 10201

--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ Audio-prompt based TTS models like Pocket-TTS can "swallow" the first word into 
 - **🔄 Last Run**: 2026-01-20 00:30:58 UTC
 - **Last Upstream SHA**: 6f9dd250c24ee85cecc5587902a684f0d82b2a0d 
 ## 📅 Release Status
-- **⏳ Last Build On**: 2026-08-29 05:53:40 UTC
-- **🔄 Last Run**: 2026-08-29 05:53:40 UTC
+- **⏳ Last Build On**: 2026-08-30 03:57:38 UTC
+- **🔄 Last Run**: 2026-08-30 03:57:38 UTC
 - **Last Upstream SHA**: ea740e517ab5e28bfaf613e52019559ac702ce2a

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ services:
       - WYOMING_PORT=10201
       - WYOMING_HOST=0.0.0.0
       - DEFAULT_VOICE=alba
-      - MODEL_VARIANT=b6369a24
+      - MODEL_VARIANT=english
       - ZEROCONF=pocket-tts
     restart: unless-stopped
     volumes:
@@ -39,7 +39,7 @@ You can customize the following environment variables in the compose file before
 | `WYOMING_PORT` | `10201` | The port the Wyoming protocol server listens on. Change if you have a conflict with another service. |
 | `WYOMING_HOST` | `0.0.0.0` | The network interface to bind to. `0.0.0.0` accepts connections from any interface. |
 | `DEFAULT_VOICE` | `alba` | The default voice used when none is specified. See [Available Voices](#available-voices) for options. |
-| `MODEL_VARIANT` | `b6369a24` | The Pocket-TTS model variant to use. This corresponds to a specific model checkpoint. |
+| `MODEL_VARIANT` | `english` | The Pocket-TTS language to use. |
 | `ZEROCONF` | `pocket-tts` | Service name for mDNS/Zeroconf discovery. Home Assistant uses this to auto-discover the TTS server. Set to empty string to disable. |
 
 Pull and start:
@@ -66,7 +66,7 @@ docker run -d \
   --name pocket-tts-wyoming \
   --network host \
   -e DEFAULT_VOICE=alba \
-  -e MODEL_VARIANT=b6369a24 \
+  -e MODEL_VARIANT=english \
   -e ZEROCONF=pocket-tts \
   -v pocket-tts-hf-cache:/root/.cache/huggingface \
   -v pocket-tts-cache:/root/.cache/pocket_tts \

--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ Audio-prompt based TTS models like Pocket-TTS can "swallow" the first word into 
 - **🔄 Last Run**: 2026-01-20 00:30:58 UTC
 - **Last Upstream SHA**: 6f9dd250c24ee85cecc5587902a684f0d82b2a0d 
 ## 📅 Release Status
-- **⏳ Last Build On**: 2026-08-30 03:57:38 UTC
-- **🔄 Last Run**: 2026-08-30 03:57:38 UTC
+- **⏳ Last Build On**: 2026-08-31 04:01:18 UTC
+- **🔄 Last Run**: 2026-08-31 04:01:18 UTC
 - **Last Upstream SHA**: ea740e517ab5e28bfaf613e52019559ac702ce2a

--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ Audio-prompt based TTS models like Pocket-TTS can "swallow" the first word into 
 - **🔄 Last Run**: 2026-01-20 00:30:58 UTC
 - **Last Upstream SHA**: 6f9dd250c24ee85cecc5587902a684f0d82b2a0d 
 ## 📅 Release Status
-- **⏳ Last Build On**: 2026-08-27 08:20:49 UTC
-- **🔄 Last Run**: 2026-08-27 08:20:49 UTC
-- **Last Upstream SHA**: 8c98c9b53663454fc4282863c53b4b4e215aba50
+- **⏳ Last Build On**: 2026-08-28 09:53:48 UTC
+- **🔄 Last Run**: 2026-08-28 09:53:48 UTC
+- **Last Upstream SHA**: a61b7878bb71e4ade8a651be6e7e9f21317e9157

--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ Audio-prompt based TTS models like Pocket-TTS can "swallow" the first word into 
 - **🔄 Last Run**: 2026-01-20 00:30:58 UTC
 - **Last Upstream SHA**: 6f9dd250c24ee85cecc5587902a684f0d82b2a0d 
 ## 📅 Release Status
-- **⏳ Last Build On**: 2026-08-28 09:53:48 UTC
-- **🔄 Last Run**: 2026-08-28 09:53:48 UTC
-- **Last Upstream SHA**: a61b7878bb71e4ade8a651be6e7e9f21317e9157
+- **⏳ Last Build On**: 2026-08-29 05:53:40 UTC
+- **🔄 Last Run**: 2026-08-29 05:53:40 UTC
+- **Last Upstream SHA**: ea740e517ab5e28bfaf613e52019559ac702ce2a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - WYOMING_PORT=10201
       - WYOMING_HOST=0.0.0.0
       - DEFAULT_VOICE=alba
-      - MODEL_VARIANT=b6369a24
+      - MODEL_VARIANT=english
       - ZEROCONF=pocket-tts
     restart: unless-stopped
     volumes:

--- a/wyoming_tts_server.py
+++ b/wyoming_tts_server.py
@@ -18,7 +18,14 @@ from typing import Optional
 import numpy
 
 from pocket_tts import TTSModel
-from pocket_tts.utils.utils import PREDEFINED_VOICES
+try:
+    from pocket_tts.utils.utils import _ORIGINS_OF_PREDEFINED_VOICES as PREDEFINED_VOICE_NAMES
+except ImportError:
+    # Fallback in case this private name also changes upstream later.
+    PREDEFINED_VOICE_NAMES = {
+        "alba": None, "marius": None, "javert": None, "jean": None,
+        "fantine": None, "cosette": None, "eponine": None, "azelma": None,
+    }
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
 from wyoming.error import Error
 from wyoming.event import Event
@@ -162,7 +169,7 @@ class PocketTTSEventHandler(AsyncEventHandler):
         if voice_name and voice_name.startswith("pocket-tts-"):
             voice_name = voice_name.replace("pocket-tts-", "", 1)
 
-        if voice_name not in PREDEFINED_VOICES:
+        if voice_name not in PREDEFINED_VOICE_NAMES:
             _LOGGER.warning(
                 "Voice '%s' not found, using default '%s'", voice_name, self.cli_args.voice
             )
@@ -403,7 +410,7 @@ async def main() -> None:
     _LOGGER.info("Sample rate: %d Hz", tts_model.sample_rate)
 
     _LOGGER.info("Pre-loading voice states for %d voices...", len(PREDEFINED_VOICES))
-    for voice_name in PREDEFINED_VOICES:
+    for voice_name in PREDEFINED_VOICE_NAMES:
         try:
             voice_state = tts_model.get_state_for_audio_prompt(voice_name)
             global _VOICE_STATES
@@ -426,7 +433,7 @@ async def main() -> None:
             languages=["en"],
             speakers=None,
         )
-        for voice_name in PREDEFINED_VOICES
+        for voice_name in PREDEFINED_VOICE_NAMES
     ]
 
     wyoming_info = Info(
@@ -483,7 +490,7 @@ async def main() -> None:
                      zeroconf_name, tcp_server.port, zeroconf_host)
 
     _LOGGER.info("Ready")
-    _LOGGER.info("Available voices: %s", ", ".join(PREDEFINED_VOICES.keys()))
+    _LOGGER.info("Available voices: %s", ", ".join(PREDEFINED_VOICE_NAMES.keys()))
     await server.run(
         partial(
             PocketTTSEventHandler,

--- a/wyoming_tts_server.py
+++ b/wyoming_tts_server.py
@@ -409,7 +409,7 @@ async def main() -> None:
     _LOGGER.info("Model loaded successfully")
     _LOGGER.info("Sample rate: %d Hz", tts_model.sample_rate)
 
-    _LOGGER.info("Pre-loading voice states for %d voices...", len(PREDEFINED_VOICES))
+    _LOGGER.info("Pre-loading voice states for %d voices...", len(PREDEFINED_VOICE_NAMES))
     for voice_name in PREDEFINED_VOICE_NAMES:
         try:
             voice_state = tts_model.get_state_for_audio_prompt(voice_name)

--- a/wyoming_tts_server.py
+++ b/wyoming_tts_server.py
@@ -18,7 +18,6 @@ from typing import Optional
 import numpy
 
 from pocket_tts import TTSModel
-from pocket_tts.default_parameters import DEFAULT_VARIANT
 from pocket_tts.utils.utils import PREDEFINED_VOICES
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
 from wyoming.error import Error
@@ -37,7 +36,10 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = int(os.environ.get("WYOMING_PORT", "10201"))
 DEFAULT_VOICE = os.environ.get("DEFAULT_VOICE", "alba")
-MODEL_VARIANT = os.environ.get("MODEL_VARIANT", DEFAULT_VARIANT)
+_LEGACY_VARIANT_MAP = {"b6369a24": "english"}
+DEFAULT_LANGUAGE = "english"
+MODEL_VARIANT = os.environ.get("MODEL_VARIANT", DEFAULT_LANGUAGE)
+MODEL_VARIANT = _LEGACY_VARIANT_MAP.get(MODEL_VARIANT, MODEL_VARIANT)
 DEBUG_WAV = os.environ.get("DEBUG_WAV", "").lower() in ("true", "1", "yes")
 
 # Prefix trimming tunables (in seconds)
@@ -394,10 +396,9 @@ async def main() -> None:
         _LOGGER.info("Debug WAV mode enabled - WAV files will be written to /output/ on every response")
     _LOGGER.debug(args)
 
-    os.environ["MODEL_VARIANT"] = args.variant
-    variant = os.environ.get("MODEL_VARIANT", MODEL_VARIANT)
-    _LOGGER.info("Loading Pocket-TTS model (variant: %s)...", variant)
-    tts_model = TTSModel.load_model(config=variant)
+    variant = _LEGACY_VARIANT_MAP.get(args.variant, args.variant)
+    _LOGGER.info("Loading Pocket-TTS model (language: %s)...", variant)
+    tts_model = TTSModel.load_model(language=variant)
     _LOGGER.info("Model loaded successfully")
     _LOGGER.info("Sample rate: %d Hz", tts_model.sample_rate)
 


### PR DESCRIPTION
## Fix container crash on pocket-tts v2.0.0+ (breaking API changes)

Since pocket-tts v2.0.0, this container crash-loops on any freshly-built or freshly-pulled image. There are two separate upstream API changes involved, plus one build fix:

### Issues addressed

1. **`TTSModel.load_model(config=...)` no longer accepts a model signature string.** As of [v2.0.0](https://github.com/kyutai-labs/pocket-tts/releases/tag/v2.0.0), `config` only accepts a path to a local YAML file (or, as of v3, an `https://`/`hf://` URL to one). Model selection is now done via the new `language=` parameter instead. This server was still calling `load_model(config=variant)` with `variant` defaulting to the old checkpoint hash `b6369a24`, which fails immediately.

2. **`PREDEFINED_VOICES` was removed from `pocket_tts.utils.utils`.** As of [v3.0.0](https://github.com/kyutai-labs/pocket-tts/releases/tag/v3.0.0), the public voice-name dict was replaced by a private `_ORIGINS_OF_PREDEFINED_VOICES` (now 28 voices, including non-English defaults). The server's top-level `from pocket_tts.utils.utils import PREDEFINED_VOICES` raises `ImportError` at startup, so the container never gets past module load.

3. **The Docker image exploded from ~500MB to ~3.25GB**. Root cause: `uv` was resolving `torch` from PyPI's default Linux wheel, which bundles CUDA (~3GB), even though this project only ever runs on CPU.

### What this PR does

- **`wyoming_tts_server.py`:** switch `load_model(config=variant)` → `load_model(language=variant)`, with a legacy map (`b6369a24` → `english`) so existing `MODEL_VARIANT=b6369a24` deployments keep working without a compose-file change.
- **`wyoming_tts_server.py`:** import `_ORIGINS_OF_PREDEFINED_VOICES` in place of `PREDEFINED_VOICES`, with a try/except fallback to the original 8-voice list in case this private name changes again upstream.
- **`Dockerfile` / `docker-compose.yml`:** pin CPU index in `pyproject.toml`. Also updated the `MODEL_VARIANT` default from `b6369a24` to `english` to match the new API, while keeping the legacy value working via the fallback above.
- **`README.md`:** updated with new `docker-compose` configuration.

### Testing

- Fresh `docker build` completes without the CUDA torch pull; image size back down to ~800MB.
- Container starts cleanly against pocket-tts 3.0.2, no crash loop.
- Verified TTS generation over the Wyoming protocol and voice discovery in Home Assistant.

Fixes the crash reported in #9.