### PR TITLE
Optional volume normalization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,6 @@ Audio-prompt based TTS models like Pocket-TTS can "swallow" the first word into 
 - **🔄 Last Run**: 2026-01-20 00:30:58 UTC
 - **Last Upstream SHA**: 6f9dd250c24ee85cecc5587902a684f0d82b2a0d 
 ## 📅 Release Status
-- **⏳ Last Build On**: 2026-09-03 03:12:56 UTC
-- **🔄 Last Run**: 2026-09-03 03:12:56 UTC
-- **Last Upstream SHA**: 60d5ad6e8afa709f9362eeb9ba64fe90ff691c90
+- **⏳ Last Build On**: 2026-09-04 03:11:43 UTC
+- **🔄 Last Run**: 2026-09-04 03:11:43 UTC
+- **Last Upstream SHA**: a3e57af8f173df46cbed8ff48e287a9fd1890750

--- a/README.md
+++ b/README.md
@@ -148,6 +148,6 @@ Audio-prompt based TTS models like Pocket-TTS can "swallow" the first word into 
 - **🔄 Last Run**: 2026-01-20 00:30:58 UTC
 - **Last Upstream SHA**: 6f9dd250c24ee85cecc5587902a684f0d82b2a0d 
 ## 📅 Release Status
-- **⏳ Last Build On**: 2026-09-02 03:40:41 UTC
-- **🔄 Last Run**: 2026-09-02 03:40:41 UTC
-- **Last Upstream SHA**: 2dd548a811fe5f74b534e06480a3970019b3dc79
+- **⏳ Last Build On**: 2026-09-03 03:12:56 UTC
+- **🔄 Last Run**: 2026-09-03 03:12:56 UTC
+- **Last Upstream SHA**: 60d5ad6e8afa709f9362eeb9ba64fe90ff691c90

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ services:
       - WYOMING_HOST=0.0.0.0
       - DEFAULT_VOICE=alba
       - MODEL_VARIANT=english
+      - NORMALIZE_AUDIO=true
+      - TARGET_RMS=0.1
       - ZEROCONF=pocket-tts
     restart: unless-stopped
     volumes:
@@ -40,6 +42,8 @@ You can customize the following environment variables in the compose file before
 | `WYOMING_HOST` | `0.0.0.0` | The network interface to bind to. `0.0.0.0` accepts connections from any interface. |
 | `DEFAULT_VOICE` | `alba` | The default voice used when none is specified. See [Available Voices](#available-voices) for options. |
 | `MODEL_VARIANT` | `english` | The Pocket-TTS language to use. |
+| `NORMALIZE_AUDIO` | `true` | Enables volume normalization. If set to `true`, all voices will have a consistent volume. |
+| `TARGET_RMS` | `0.1` | Target RMS for volume normalization (`0.1` = ~ -20 dBFS). Only used if `NORMALIZE_AUDIO` is `true`. |
 | `ZEROCONF` | `pocket-tts` | Service name for mDNS/Zeroconf discovery. Home Assistant uses this to auto-discover the TTS server. Set to empty string to disable. |
 
 Pull and start:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,6 @@ Audio-prompt based TTS models like Pocket-TTS can "swallow" the first word into 
 - **🔄 Last Run**: 2026-01-20 00:30:58 UTC
 - **Last Upstream SHA**: 6f9dd250c24ee85cecc5587902a684f0d82b2a0d 
 ## 📅 Release Status
-- **⏳ Last Build On**: 2026-09-04 03:11:43 UTC
-- **🔄 Last Run**: 2026-09-04 03:11:43 UTC
+- **⏳ Last Build On**: 2026-09-05 03:14:30 UTC
+- **🔄 Last Run**: 2026-09-05 03:14:30 UTC
 - **Last Upstream SHA**: a3e57af8f173df46cbed8ff48e287a9fd1890750

--- a/README.md
+++ b/README.md
@@ -148,6 +148,6 @@ Audio-prompt based TTS models like Pocket-TTS can "swallow" the first word into 
 - **🔄 Last Run**: 2026-01-20 00:30:58 UTC
 - **Last Upstream SHA**: 6f9dd250c24ee85cecc5587902a684f0d82b2a0d 
 ## 📅 Release Status
-- **⏳ Last Build On**: 2026-09-06 03:14:13 UTC
-- **🔄 Last Run**: 2026-09-06 03:14:13 UTC
+- **⏳ Last Build On**: 2026-09-07 03:12:24 UTC
+- **🔄 Last Run**: 2026-09-07 03:12:24 UTC
 - **Last Upstream SHA**: f544a39b07db56fadeed575d57a33e1eda17c022

--- a/README.md
+++ b/README.md
@@ -148,6 +148,6 @@ Audio-prompt based TTS models like Pocket-TTS can "swallow" the first word into 
 - **🔄 Last Run**: 2026-01-20 00:30:58 UTC
 - **Last Upstream SHA**: 6f9dd250c24ee85cecc5587902a684f0d82b2a0d 
 ## 📅 Release Status
-- **⏳ Last Build On**: 2026-09-07 03:12:24 UTC
-- **🔄 Last Run**: 2026-09-07 03:12:24 UTC
-- **Last Upstream SHA**: f544a39b07db56fadeed575d57a33e1eda17c022
+- **⏳ Last Build On**: 2026-09-08 03:20:32 UTC
+- **🔄 Last Run**: 2026-09-08 03:20:32 UTC
+- **Last Upstream SHA**: 063171d12c6b25d734e7fa019eb76a7954a77233

--- a/README.md
+++ b/README.md
@@ -148,6 +148,6 @@ Audio-prompt based TTS models like Pocket-TTS can "swallow" the first word into 
 - **🔄 Last Run**: 2026-01-20 00:30:58 UTC
 - **Last Upstream SHA**: 6f9dd250c24ee85cecc5587902a684f0d82b2a0d 
 ## 📅 Release Status
-- **⏳ Last Build On**: 2026-09-05 03:14:30 UTC
-- **🔄 Last Run**: 2026-09-05 03:14:30 UTC
-- **Last Upstream SHA**: a3e57af8f173df46cbed8ff48e287a9fd1890750
+- **⏳ Last Build On**: 2026-09-06 03:14:13 UTC
+- **🔄 Last Run**: 2026-09-06 03:14:13 UTC
+- **Last Upstream SHA**: f544a39b07db56fadeed575d57a33e1eda17c022

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - WYOMING_HOST=0.0.0.0
       - DEFAULT_VOICE=alba
       - MODEL_VARIANT=english
+      - NORMALIZE_AUDIO=true
+      - TARGET_RMS=0.1
       - ZEROCONF=pocket-tts
     restart: unless-stopped
     volumes:

--- a/wyoming_tts_server.py
+++ b/wyoming_tts_server.py
@@ -48,6 +48,8 @@ DEFAULT_LANGUAGE = "english"
 MODEL_VARIANT = os.environ.get("MODEL_VARIANT", DEFAULT_LANGUAGE)
 MODEL_VARIANT = _LEGACY_VARIANT_MAP.get(MODEL_VARIANT, MODEL_VARIANT)
 DEBUG_WAV = os.environ.get("DEBUG_WAV", "").lower() in ("true", "1", "yes")
+NORMALIZE_AUDIO = os.environ.get("NORMALIZE_AUDIO", "true").lower() in ("true", "1", "yes")
+TARGET_RMS = float(os.environ.get("TARGET_RMS", "0.1"))  # ~ -20 dBFS, adjust to taste
 
 # Prefix trimming tunables (in seconds)
 # Minimum time before looking for the pause after the sacrificial prefix
@@ -287,6 +289,7 @@ class PocketTTSEventHandler(AsyncEventHandler):
                         last_non_silent = non_silent_indices[-1] + padding_samples
                         full_audio = full_audio[:last_non_silent + 1]
 
+                full_audio = _normalize_audio(full_audio)
                 full_audio = (full_audio.clip(-1.0, 1.0) * 32767).astype("int16")
                 audio_bytes = full_audio.tobytes()
 
@@ -330,6 +333,15 @@ class PocketTTSEventHandler(AsyncEventHandler):
 
         return True
 
+def _normalize_audio(audio: numpy.ndarray) -> numpy.ndarray:
+    """Bring all voices to a comparable perceived loudness (RMS-based)."""
+    if not NORMALIZE_AUDIO:
+        return audio
+    rms = numpy.sqrt(numpy.mean(numpy.square(audio)))
+    if rms < 1e-6:
+        return audio  # near-silence; avoid divide-by-zero / noise amplification
+    gain = min(TARGET_RMS / rms, 10.0)  # cap gain so we don't blow up quiet artifacts
+    return audio * gain
 
 async def main() -> None:
     """Main entry point."""


### PR DESCRIPTION
Adds support for volume normalization, which is controlled via two new environment variables:

`NORMALIZE_AUDIO`: Enables volume normalization. Defaults to `true`, in which case all voice output will use a consistent volume.
`TARGET_RMS`: Target RMS for volume normalization (Defaults to `0.1` or ~ -20 dBFS). Only used if `NORMALIZE_AUDIO` is `true`.

Updated `README.md` and `docker-compose.yml` to include the new variables.